### PR TITLE
Changed core pool size to number of processors

### DIFF
--- a/tracer-spring-boot-starter/src/main/java/org/zalando/tracer/spring/TracerSchedulingAutoConfiguration.java
+++ b/tracer-spring-boot-starter/src/main/java/org/zalando/tracer/spring/TracerSchedulingAutoConfiguration.java
@@ -40,7 +40,7 @@ public class TracerSchedulingAutoConfiguration implements SchedulingConfigurer {
         @Bean(destroyMethod = "shutdown")
         @ConditionalOnMissingBean(name = "taskSchedulerService")
         public ScheduledExecutorService taskSchedulerService() {
-            return newScheduledThreadPool(0);
+            return newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
         }
 
         @Bean(name = DEFAULT_TASK_SCHEDULER_BEAN_NAME)


### PR DESCRIPTION
See http://stackoverflow.com/questions/15888366/meaning-of-core-pool-size-in-scheduledthreadpoolexecutors-constructor#comment39019434_15888497

> Unfortunately ScheduledThreadPoolExecutor does not treat these parameters the same as ThreadPoolExecutor. STPE acts as a fixed thread pool of size 'corePoolSize' and does not create any additional threads. maximumPoolSize does nothing