### PR TITLE
GH-88 Improves Random128Generator performance

### DIFF
--- a/tracer-core/src/main/java/org/zalando/tracer/Chars.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Chars.java
@@ -1,0 +1,31 @@
+package org.zalando.tracer;
+
+class Chars {
+
+    private Chars() {
+    }
+
+    private static final char[] DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+    };
+
+    static void toLowerHex(long value, char[] chars, int offset) {
+        chars[offset + 0] = DIGITS[(int) (value >> 4 * 0) & 0x0f];
+        chars[offset + 1] = DIGITS[(int) (value >> 4 * 1) & 0x0f];
+        chars[offset + 2] = DIGITS[(int) (value >> 4 * 2) & 0x0f];
+        chars[offset + 3] = DIGITS[(int) (value >> 4 * 3) & 0x0f];
+        chars[offset + 4] = DIGITS[(int) (value >> 4 * 4) & 0x0f];
+        chars[offset + 5] = DIGITS[(int) (value >> 4 * 5) & 0x0f];
+        chars[offset + 6] = DIGITS[(int) (value >> 4 * 6) & 0x0f];
+        chars[offset + 7] = DIGITS[(int) (value >> 4 * 7) & 0x0f];
+        chars[offset + 8] = DIGITS[(int) (value >> 4 * 8) & 0x0f];
+        chars[offset + 9] = DIGITS[(int) (value >> 4 * 9) & 0x0f];
+        chars[offset + 10] = DIGITS[(int) (value >> 4 * 10) & 0x0f];
+        chars[offset + 11] = DIGITS[(int) (value >> 4 * 11) & 0x0f];
+        chars[offset + 12] = DIGITS[(int) (value >> 4 * 12) & 0x0f];
+        chars[offset + 13] = DIGITS[(int) (value >> 4 * 13) & 0x0f];
+        chars[offset + 14] = DIGITS[(int) (value >> 4 * 14) & 0x0f];
+        chars[offset + 15] = DIGITS[(int) (value >> 4 * 15) & 0x0f];
+    }
+}

--- a/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
@@ -12,39 +12,15 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @API(status = EXPERIMENTAL)
 public final class Random128Generator implements Generator {
 
-    private static final char[] DIGITS = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
-    };
-
     @Override
     public String generate() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         char[] chars = new char[32];
 
-        long2hex(chars, 0, random.nextLong());
-        long2hex(chars, 16, random.nextLong());
+        Random64Generator.long2hex(chars, 0, random.nextLong());
+        Random64Generator.long2hex(chars, 16, random.nextLong());
 
         return new String(chars);
-    }
-
-    private void long2hex(char[] chars, int offset, long r) {
-        chars[offset + 0] = DIGITS[(int) (r >> 4 * 0) & 0x0f];
-        chars[offset + 1] = DIGITS[(int) (r >> 4 * 1) & 0x0f];
-        chars[offset + 2] = DIGITS[(int) (r >> 4 * 2) & 0x0f];
-        chars[offset + 3] = DIGITS[(int) (r >> 4 * 3) & 0x0f];
-        chars[offset + 4] = DIGITS[(int) (r >> 4 * 4) & 0x0f];
-        chars[offset + 5] = DIGITS[(int) (r >> 4 * 5) & 0x0f];
-        chars[offset + 6] = DIGITS[(int) (r >> 4 * 6) & 0x0f];
-        chars[offset + 7] = DIGITS[(int) (r >> 4 * 7) & 0x0f];
-        chars[offset + 8] = DIGITS[(int) (r >> 4 * 8) & 0x0f];
-        chars[offset + 9] = DIGITS[(int) (r >> 4 * 9) & 0x0f];
-        chars[offset + 10] = DIGITS[(int) (r >> 4 * 10) & 0x0f];
-        chars[offset + 11] = DIGITS[(int) (r >> 4 * 11) & 0x0f];
-        chars[offset + 12] = DIGITS[(int) (r >> 4 * 12) & 0x0f];
-        chars[offset + 13] = DIGITS[(int) (r >> 4 * 13) & 0x0f];
-        chars[offset + 14] = DIGITS[(int) (r >> 4 * 14) & 0x0f];
-        chars[offset + 15] = DIGITS[(int) (r >> 4 * 15) & 0x0f];
     }
 }

--- a/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
@@ -18,8 +18,8 @@ public final class Random128Generator implements Generator {
 
         char[] chars = new char[32];
 
-        Random64Generator.long2hex(chars, 0, random.nextLong());
-        Random64Generator.long2hex(chars, 16, random.nextLong());
+        Chars.toLowerHex(random.nextLong(), chars, 0);
+        Chars.toLowerHex(random.nextLong(), chars, 16);
 
         return new String(chars);
     }

--- a/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Random128Generator.java
@@ -2,6 +2,8 @@ package org.zalando.tracer;
 
 import org.apiguardian.api.API;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
@@ -10,11 +12,39 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @API(status = EXPERIMENTAL)
 public final class Random128Generator implements Generator {
 
-    private final Random64Generator random64 = new Random64Generator();
+    private static final char[] DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+    };
 
     @Override
     public String generate() {
-        return random64.generate() + random64.generate();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        char[] chars = new char[32];
+
+        long2hex(chars, 0, random.nextLong());
+        long2hex(chars, 16, random.nextLong());
+
+        return new String(chars);
     }
 
+    private void long2hex(char[] chars, int offset, long r) {
+        chars[offset + 0] = DIGITS[(int) (r >> 4 * 0) & 0x0f];
+        chars[offset + 1] = DIGITS[(int) (r >> 4 * 1) & 0x0f];
+        chars[offset + 2] = DIGITS[(int) (r >> 4 * 2) & 0x0f];
+        chars[offset + 3] = DIGITS[(int) (r >> 4 * 3) & 0x0f];
+        chars[offset + 4] = DIGITS[(int) (r >> 4 * 4) & 0x0f];
+        chars[offset + 5] = DIGITS[(int) (r >> 4 * 5) & 0x0f];
+        chars[offset + 6] = DIGITS[(int) (r >> 4 * 6) & 0x0f];
+        chars[offset + 7] = DIGITS[(int) (r >> 4 * 7) & 0x0f];
+        chars[offset + 8] = DIGITS[(int) (r >> 4 * 8) & 0x0f];
+        chars[offset + 9] = DIGITS[(int) (r >> 4 * 9) & 0x0f];
+        chars[offset + 10] = DIGITS[(int) (r >> 4 * 10) & 0x0f];
+        chars[offset + 11] = DIGITS[(int) (r >> 4 * 11) & 0x0f];
+        chars[offset + 12] = DIGITS[(int) (r >> 4 * 12) & 0x0f];
+        chars[offset + 13] = DIGITS[(int) (r >> 4 * 13) & 0x0f];
+        chars[offset + 14] = DIGITS[(int) (r >> 4 * 14) & 0x0f];
+        chars[offset + 15] = DIGITS[(int) (r >> 4 * 15) & 0x0f];
+    }
 }

--- a/tracer-core/src/main/java/org/zalando/tracer/Random64Generator.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Random64Generator.java
@@ -12,38 +12,14 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @API(status = EXPERIMENTAL)
 public final class Random64Generator implements Generator {
 
-    private static final char[] DIGITS = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
-    };
-
     @Override
     public String generate() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         char[] chars = new char[16];
 
-        long2hex(chars, 0, random.nextLong());
+        Chars.toLowerHex(random.nextLong(), chars, 0);
 
         return new String(chars);
-    }
-
-    protected static void long2hex(char[] chars, int offset, long r) {
-        chars[offset + 0] = DIGITS[(int) (r >> 4 * 0) & 0x0f];
-        chars[offset + 1] = DIGITS[(int) (r >> 4 * 1) & 0x0f];
-        chars[offset + 2] = DIGITS[(int) (r >> 4 * 2) & 0x0f];
-        chars[offset + 3] = DIGITS[(int) (r >> 4 * 3) & 0x0f];
-        chars[offset + 4] = DIGITS[(int) (r >> 4 * 4) & 0x0f];
-        chars[offset + 5] = DIGITS[(int) (r >> 4 * 5) & 0x0f];
-        chars[offset + 6] = DIGITS[(int) (r >> 4 * 6) & 0x0f];
-        chars[offset + 7] = DIGITS[(int) (r >> 4 * 7) & 0x0f];
-        chars[offset + 8] = DIGITS[(int) (r >> 4 * 8) & 0x0f];
-        chars[offset + 9] = DIGITS[(int) (r >> 4 * 9) & 0x0f];
-        chars[offset + 10] = DIGITS[(int) (r >> 4 * 10) & 0x0f];
-        chars[offset + 11] = DIGITS[(int) (r >> 4 * 11) & 0x0f];
-        chars[offset + 12] = DIGITS[(int) (r >> 4 * 12) & 0x0f];
-        chars[offset + 13] = DIGITS[(int) (r >> 4 * 13) & 0x0f];
-        chars[offset + 14] = DIGITS[(int) (r >> 4 * 14) & 0x0f];
-        chars[offset + 15] = DIGITS[(int) (r >> 4 * 15) & 0x0f];
     }
 }

--- a/tracer-core/src/main/java/org/zalando/tracer/Random64Generator.java
+++ b/tracer-core/src/main/java/org/zalando/tracer/Random64Generator.java
@@ -12,11 +12,38 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @API(status = EXPERIMENTAL)
 public final class Random64Generator implements Generator {
 
+    private static final char[] DIGITS = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+    };
+
     @Override
     public String generate() {
-        final ThreadLocalRandom random = ThreadLocalRandom.current();
-        // set most significant bit to produce fixed length string
-        return Long.toHexString(random.nextLong() | Long.MIN_VALUE);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        char[] chars = new char[16];
+
+        long2hex(chars, 0, random.nextLong());
+
+        return new String(chars);
     }
 
+    protected static void long2hex(char[] chars, int offset, long r) {
+        chars[offset + 0] = DIGITS[(int) (r >> 4 * 0) & 0x0f];
+        chars[offset + 1] = DIGITS[(int) (r >> 4 * 1) & 0x0f];
+        chars[offset + 2] = DIGITS[(int) (r >> 4 * 2) & 0x0f];
+        chars[offset + 3] = DIGITS[(int) (r >> 4 * 3) & 0x0f];
+        chars[offset + 4] = DIGITS[(int) (r >> 4 * 4) & 0x0f];
+        chars[offset + 5] = DIGITS[(int) (r >> 4 * 5) & 0x0f];
+        chars[offset + 6] = DIGITS[(int) (r >> 4 * 6) & 0x0f];
+        chars[offset + 7] = DIGITS[(int) (r >> 4 * 7) & 0x0f];
+        chars[offset + 8] = DIGITS[(int) (r >> 4 * 8) & 0x0f];
+        chars[offset + 9] = DIGITS[(int) (r >> 4 * 9) & 0x0f];
+        chars[offset + 10] = DIGITS[(int) (r >> 4 * 10) & 0x0f];
+        chars[offset + 11] = DIGITS[(int) (r >> 4 * 11) & 0x0f];
+        chars[offset + 12] = DIGITS[(int) (r >> 4 * 12) & 0x0f];
+        chars[offset + 13] = DIGITS[(int) (r >> 4 * 13) & 0x0f];
+        chars[offset + 14] = DIGITS[(int) (r >> 4 * 14) & 0x0f];
+        chars[offset + 15] = DIGITS[(int) (r >> 4 * 15) & 0x0f];
+    }
 }


### PR DESCRIPTION
See #88 

# Baseline
```
Benchmark                               Mode  Cnt         Score         Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    412334.003 ±   24319.492  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    324407.107 ±   15611.498  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20   6768561.581 ±  271955.381  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19070811.389 ± 1768458.433  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    466994.520 ±    9541.360  ops/s
```

# Result
```
Benchmark                               Mode  Cnt         Score         Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    397152.625 ±   36858.046  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    332155.255 ±   12639.661  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20  17251424.583 ± 2940793.297  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19812257.856 ±  177725.061  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    457482.726 ±   16308.116  ops/s
```

# Other attempts

## Byte array

```java
public final class Random128Generator implements Generator {

    private static final byte[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        ThreadLocalRandom random = ThreadLocalRandom.current();
        byte[] bytes = new byte[128 / 8 * 2];
        for (int i = 0; i < bytes.length; i++) {
            bytes[i] = DIGITS[random.nextInt(DIGITS.length)];
        }
        return new String(bytes, US_ASCII);
    }
}
```
```
Benchmark                               Mode  Cnt         Score        Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    397249.420 ±  51845.892  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    313868.810 ±  30338.359  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20   6278747.048 ± 316635.519  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19193646.981 ± 628193.199  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    453820.857 ±   7525.596  ops/s
```
## Char array

```java
public final class Random128Generator implements Generator {

    private static final char[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        ThreadLocalRandom random = ThreadLocalRandom.current();
        char[] chars = new char[128 / 8 * 2];
        for (int i = 0; i < chars.length; i++) {
            chars[i] = DIGITS[random.nextInt(DIGITS.length)];
        }
        return new String(chars);
    }
}
```
```
Benchmark                               Mode  Cnt         Score        Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    424805.014 ±   9988.516  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    328622.606 ±   8620.456  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20   9582288.803 ± 276783.309  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19215330.543 ± 851336.935  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    453417.599 ±   5895.046  ops/s
```
## Chars cached length

```java
public final class Random128Generator implements Generator {

    private static final char[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        ThreadLocalRandom random = ThreadLocalRandom.current();

        int length = 128 / 8 * 2;
        char[] chars = new char[length];
        int digitCount = DIGITS.length;
        for (int i = 0; i < length; i++) {
            chars[i] = DIGITS[random.nextInt(digitCount)];
        }
        return new String(chars);
    }
}
```
```
Benchmark                               Mode  Cnt         Score        Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    438744.885 ±  10394.207  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    340894.677 ±   5124.502  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20  10066511.118 ± 269362.716  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  20102507.398 ± 190068.006  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    461722.559 ±  29203.053  ops/s
```
## Chars remainder extracted

```java
public final class Random128Generator implements Generator {

    private static final char[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        final ThreadLocalRandom random = ThreadLocalRandom.current();
        final int length = 128 / 8 * 2;
        final char[] chars = new char[length];
        for (int i = 0; i < length; i++) {
            chars[i] = DIGITS[random.nextInt() & 15];
        }
        return new String(chars);
    }
}
```
```
Benchmark                               Mode  Cnt         Score       Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    429027.246 ± 19407.913  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    347280.213 ±  3043.878  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20  10423571.183 ± 64430.837  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  20679680.284 ± 93623.829  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    474269.450 ±  1999.602  ops/s
```
## Chars single nextInt

```java
public final class Random128Generator implements Generator {

    private static final char[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        final ThreadLocalRandom random = ThreadLocalRandom.current();
        final int length = 128 / 8 * 2;
        final char[] chars = new char[length];
        for (int i = 0; i < length / 4; i++) {
            final int r = random.nextInt();
            chars[i * 4 + 0] = DIGITS[(r >> 8 * 0) & 0x0f];
            chars[i * 4 + 1] = DIGITS[(r >> 8 * 1) & 0x0f];
            chars[i * 4 + 2] = DIGITS[(r >> 8 * 2) & 0x0f];
            chars[i * 4 + 3] = DIGITS[(r >> 8 * 3) & 0x0f];
        }
        return new String(chars);
    }
}
```
```
Benchmark                               Mode  Cnt         Score        Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    443104.256 ±   3590.557  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    324898.703 ±  22601.942  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20  16255936.502 ± 444812.618  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19729049.362 ± 455338.707  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    428339.174 ±  35389.141  ops/s
```
## Chars nextInt unrolled

```java
public final class Random128Generator implements Generator {

    private static final char[] DIGITS = {
            '0', '1', '2', '3', '4', '5', '6', '7',
            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
    };

    @Override
    public String generate() {
        ThreadLocalRandom random = ThreadLocalRandom.current();
        final char[] digits = DIGITS;
        char[] chars = new char[32];

        int r = random.nextInt();

        chars[0] = digits[(r >> 4 * 0) & 0x0f];
        chars[1] = digits[(r >> 4 * 1) & 0x0f];
        chars[2] = digits[(r >> 4 * 2) & 0x0f];
        chars[3] = digits[(r >> 4 * 3) & 0x0f];
        chars[4] = digits[(r >> 4 * 4) & 0x0f];
        chars[5] = digits[(r >> 4 * 5) & 0x0f];
        chars[6] = digits[(r >> 4 * 6) & 0x0f];
        chars[7] = digits[(r >> 4 * 7) & 0x0f];

        r = random.nextInt();

        chars[8] = digits[(r >> 4 * 0) & 0x0f];
        chars[9] = digits[(r >> 4 * 1) & 0x0f];
        chars[10] = digits[(r >> 4 * 2) & 0x0f];
        chars[11] = digits[(r >> 4 * 3) & 0x0f];
        chars[12] = digits[(r >> 4 * 4) & 0x0f];
        chars[13] = digits[(r >> 4 * 5) & 0x0f];
        chars[14] = digits[(r >> 4 * 6) & 0x0f];
        chars[15] = digits[(r >> 4 * 7) & 0x0f];

        r = random.nextInt();

        chars[16] = digits[(r >> 4 * 0) & 0x0f];
        chars[17] = digits[(r >> 4 * 1) & 0x0f];
        chars[18] = digits[(r >> 4 * 2) & 0x0f];
        chars[19] = digits[(r >> 4 * 3) & 0x0f];
        chars[20] = digits[(r >> 4 * 4) & 0x0f];
        chars[21] = digits[(r >> 4 * 5) & 0x0f];
        chars[22] = digits[(r >> 4 * 6) & 0x0f];
        chars[23] = digits[(r >> 4 * 7) & 0x0f];

        r = random.nextInt();

        chars[24] = digits[(r >> 4 * 0) & 0x0f];
        chars[25] = digits[(r >> 4 * 1) & 0x0f];
        chars[26] = digits[(r >> 4 * 2) & 0x0f];
        chars[27] = digits[(r >> 4 * 3) & 0x0f];
        chars[28] = digits[(r >> 4 * 4) & 0x0f];
        chars[29] = digits[(r >> 4 * 5) & 0x0f];
        chars[30] = digits[(r >> 4 * 6) & 0x0f];
        chars[31] = digits[(r >> 4 * 7) & 0x0f];

        return new String(chars);
    }
}
```
```
Benchmark                               Mode  Cnt         Score         Error  Units
FlowIDGeneratorBenchmark.benchmark     thrpt   20    389890.021 ±   10933.431  ops/s
PhraseGeneratorBenchmark.benchmark     thrpt   20    310139.927 ±    2835.439  ops/s
Random128GeneratorBenchmark.benchmark  thrpt   20  18959431.979 ± 1625424.463  ops/s
Random64GeneratorBenchmark.benchmark   thrpt   20  19755570.048 ±  226995.209  ops/s
UUIDGeneratorBenchmark.benchmark       thrpt   20    443389.018 ±   18707.907  ops/s
```
