### PR TITLE
Added bill of materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This library historically originates from a closed-source implementation called 
 
 ## Installation
 
-Selectively add the following dependencies to your project:
+Add the following dependency to your project:
 
 ```xml
 <dependency>
@@ -49,41 +49,60 @@ Selectively add the following dependencies to your project:
     <artifactId>tracer-core</artifactId>
     <version>${tracer.version}</version>
 </dependency>
+```
+
+Additional modules/artifacts of Tracer always share the same version number.
+
+Alternatively, you can import our *bill of materials*...
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>tracer-bom</artifactId>
+      <version>${tracer.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+... which allows you to omit versions and scopes:
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>tracer-core</artifactId>
+</dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-servlet</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-httpclient</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-okhttp</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-hystrix</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-aspectj</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-junit</artifactId>
-    <version>${tracer.version}</version>
-    <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>tracer-spring-boot-starter</artifactId>
-    <version>${tracer.version}</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <modules>
         <module>tracer-aspectj</module>
         <module>tracer-benchmark</module>
+        <module>tracer-bom</module>
         <module>tracer-core</module>
         <module>tracer-httpclient</module>
         <module>tracer-hystrix</module>
@@ -82,6 +83,22 @@
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>tracer-httpclient</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-hystrix</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-junit</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-okhttp</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tracer-bom/pom.xml
+++ b/tracer-bom/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>tracer-parent</artifactId>
+        <version>0.17.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tracer-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Tracer: Bill of Materials</name>
+    <description>Tracing requests through a distributed system.</description>
+
+    <scm>
+        <url>https://github.com/zalando/tracer</url>
+        <connection>scm:git:git@github.com:zalando/tracer.git</connection>
+        <developerConnection>scm:git:git@github.com:zalando/tracer.git</developerConnection>
+    </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-aspectj</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-core</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-httpclient</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-hystrix</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-junit</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-okhttp</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-servlet</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>tracer-spring-boot-starter</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tracer has already 5+ modules that produce individual artifacts. Users that depend on them will usually list them all as dependencies in their POMs. Right now we guarantee that version numbers across modules are always the same, i.e. a new release will release each module, even if it wasn't change.
That allows users right now already to use a single maven property `tracer.version` that is used for each dependency. 

This pull requests introduces a BOM (bill of material) as an alternative. The BOM can be imported in the `dependencyManagement` section of a POM. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The BOM removes the need to specify any version on individual tracer artifacts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
