### PR TITLE
Expose flow as header on servlet response

### DIFF
--- a/tracer-servlet/src/main/java/org/zalando/tracer/servlet/FlowFilter.java
+++ b/tracer-servlet/src/main/java/org/zalando/tracer/servlet/FlowFilter.java
@@ -2,7 +2,6 @@ package org.zalando.tracer.servlet;
 
 import org.apiguardian.api.API;
 import org.zalando.tracer.Flow;
-
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -24,7 +23,14 @@ public final class FlowFilter implements HttpFilter {
     public void doFilter(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain chain) throws IOException, ServletException {
         flow.readFrom(request::getHeader);
+        if (isLegacyRequest(request)) {
+            flow.writeTo(response::setHeader);
+        }
         chain.doFilter(request, response);
+    }
+
+    private boolean isLegacyRequest(final HttpServletRequest request) {
+        return request.getHeader(Flow.Header.FLOW_ID) != null;
     }
 
 }

--- a/tracer-servlet/src/test/java/org/zalando/tracer/servlet/FlowFilterTest.java
+++ b/tracer-servlet/src/test/java/org/zalando/tracer/servlet/FlowFilterTest.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletResponse;
 import static com.jayway.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -37,7 +39,8 @@ final class FlowFilterTest {
                 .header("spanid", "1")
                 .get(url())
                 .then()
-                .content(equalTo("1"));
+                .content(equalTo("1"))
+                .header("x-flow-id", is(nullValue()));
     }
 
     @Test
@@ -49,7 +52,20 @@ final class FlowFilterTest {
                 .header("baggage-flow_id", "REcCvlqMSReeo7adheiYFA")
                 .get(url())
                 .then()
-                .content(equalTo("REcCvlqMSReeo7adheiYFA"));
+                .content(equalTo("REcCvlqMSReeo7adheiYFA"))
+                .header("x-flow-id", is(nullValue()));
+    }
+
+    @Test
+    void shouldPropagateFlowAsFlowIdHeader() {
+        given().
+                when()
+                .header("traceid", "1")
+                .header("spanid", "2")
+                .header("x-flow-id", "3")
+                .get(url())
+                .then()
+                .header("x-flow-id", equalTo("3"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Expose flow (id) as `x-flow-id` header in servlet response.

## Motivation and Context

* aligning response header with propagation matrix of https://github.com/zalando/tracer#usage
* ensuring backwards compatibility (tracing based on `x-flow-id` header)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
